### PR TITLE
Support for current-region in check-cloudtrail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,9 +73,15 @@ Quick Install
 
 ::
 
-  $ virtualenv custodian
+  $ virtualenv --python=python2 custodian
   $ source custodian/bin/activate
-  $ pip install c7n
+  (custodian) $ pip install c7n
+
+(Note that Custodian's `Lambda features
+<http://www.capitalone.io/cloud-custodian/docs/policy/lambda.html>`_ currently
+`do not work <https://github.com/capitalone/cloud-custodian/issues/193>`_
+outside of a virtualenv.)
+
 
 Usage
 #####

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -197,7 +197,10 @@ class StateTransitionAge(AgeFilter):
         v = i.get('StateTransitionReason')
         if not v:
             return None
-        return parse(self.RE_PARSE_AGE.findall(v)[0][1:-1])
+        dates = self.RE_PARSE_AGE.findall(v)
+        if dates:
+            return parse(dates[0][1:-1])
+        return None
 
 
 class StateTransitionFilter(object):

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1586,10 +1586,6 @@ class DeleteBucket(ScanBucket):
                 self.log.error(
                     "Error while deleting bucket %s, bucket not empty" % (
                         b['Name']))
-            elif e.response['Error']['Code'] == 'AccessDenied':
-                self.log.error(
-                    "Error while deleting bucket %s, access denied" % (
-                        b['Name']))
             else:
                 raise e
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1055,6 +1055,12 @@ class NetworkAcl(QueryResourceManager):
         id_prefix = "acl-"
 
 
+@NetworkAcl.filter_registry.register('subnet')
+class AclSubnetFilter(net_filters.SubnetFilter):
+
+    RelatedIdsExpression = "Associations[].SubnetId"
+
+
 @resources.register('network-addr')
 class Address(QueryResourceManager):
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -17,6 +17,8 @@ import itertools
 import operator
 import zlib
 
+import jmespath
+
 from c7n.actions import BaseAction, ModifyVpcSecurityGroupsAction
 from c7n.filters import (
     DefaultVpcBase, Filter, FilterValidationError, ValueFilter)
@@ -24,7 +26,8 @@ import c7n.filters.vpc as net_filters
 from c7n.filters.revisions import Diff
 from c7n.query import QueryResourceManager
 from c7n.manager import resources
-from c7n.utils import local_session, type_schema, get_retry, camelResource
+from c7n.utils import (
+    local_session, type_schema, get_retry, camelResource, parse_cidr)
 
 
 @resources.register('vpc')
@@ -516,7 +519,7 @@ class Stale(Filter):
     schema = type_schema('stale')
     permissions = ('ec2:DescribeStaleSecurityGroups',)
 
-    def process(self, resources, events):
+    def process(self, resources, event=None):
         client = local_session(self.manager.session_factory).client('ec2')
         vpc_ids = set([r['VpcId'] for r in resources if 'VpcId' in r])
         group_map = {r['GroupId']: r for r in resources}
@@ -1057,8 +1060,79 @@ class NetworkAcl(QueryResourceManager):
 
 @NetworkAcl.filter_registry.register('subnet')
 class AclSubnetFilter(net_filters.SubnetFilter):
+    """Filter network acls by the attributes of their attached subnets.
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: subnet-acl
+                resource: network-acl
+                filters:
+                  - type: subnet
+                    key: "tag:Location"
+                    value: Public
+    """
 
     RelatedIdsExpression = "Associations[].SubnetId"
+
+
+@NetworkAcl.filter_registry.register('s3-cidr')
+class AclAwsS3Cidrs(Filter):
+    """Filter network acls by those that allow access to s3 cidrs.
+
+    Defaults to filtering those nacls that do not allow s3 communication.
+
+    :example:
+
+        Find all nacls that do not allow communication with s3.
+
+        .. code-block: yaml
+
+            policies:
+              - name: s3-not-allowed-nacl
+                resource: network-acl
+                filters:
+                  - s3-cidr
+    """
+    # TODO allow for port specification as range
+    schema = type_schema(
+        's3-cidr',
+        egress={'type': 'boolean', 'default': True},
+        ingress={'type': 'boolean', 'default': True},
+        present={'type': 'boolean', 'default': False})
+
+    permissions = ('ec2:DescribePrefixLists',)
+
+    def process(self, resources, event=None):
+        ec2 = local_session(self.manager.session_factory).client('ec2')
+        cidrs = jmespath.search(
+            "PrefixLists[].Cidrs[]", ec2.describe_prefix_lists())
+        cidrs = [parse_cidr(cidr) for cidr in cidrs]
+        results = []
+
+        check_egress = self.data.get('egress', True)
+        check_ingress = self.data.get('ingress', True)
+        present = self.data.get('present', False)
+
+        for r in resources:
+            matched = {cidr: None for cidr in cidrs}
+            for entry in r['Entries']:
+                if entry['Egress'] and not check_egress:
+                    continue
+                if not entry['Egress'] and not check_ingress:
+                    continue
+                entry_cidr = parse_cidr(entry['CidrBlock'])
+                for c in matched:
+                    if c in entry_cidr and matched[c] is None:
+                        matched[c] = (
+                            entry['RuleAction'] == 'allow' and True or False)
+            if present and all(matched.values()):
+                results.append(r)
+            elif not present and not all(matched.values()):
+                results.append(r)
+        return results
 
 
 @resources.register('network-addr')
@@ -1155,5 +1229,4 @@ class KeyPair(QueryResourceManager):
         name = 'KeyName'
         date = None
         dimension = None
-
 

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -269,7 +269,7 @@ def process_resource(type_name, resource_type, resource_defs):
         else:
             filters_seen.add(f)
 
-        if filter_name in ('or', 'and'):
+        if filter_name in ('or', 'and', 'not'):
             continue
         elif filter_name == 'value':
             r['filters'][filter_name] = {
@@ -279,17 +279,6 @@ def process_resource(type_name, resource_type, resource_defs):
         elif filter_name == 'event':
             r['filters'][filter_name] = {
                 '$ref': '#/definitions/filters/event'}
-        # Commenting out what appears to be dead code.  These two conditions
-        # will always match the first if statement above.  With Kapil's
-        # blessing we I will remove these lines.
-        #elif filter_name == 'or':
-        #    r['filters'][filter_name] = {
-        #        'type': 'array',
-        #        'items': {'anyOf': nested_filter_refs}}
-        #elif filter_name == 'and':
-        #    r['filters'][filter_name] = {
-        #        'type': 'array',
-        #        'items': {'anyOf': nested_filter_refs}}
         else:
             r['filters'][filter_name] = f.schema
         filter_refs.append(

--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -10,80 +10,85 @@ different Amazon services can be used as event sources.
 CloudWatch Events
 #################
 
-CloudWatch Events (CWE) is a general event bus for AWS infrastructure. Currently,
-it covers several major sources of information: CloudTrail API calls
-over a poll period on CloudTrail delivery, real-time instance status
-events, autoscale group notifications, and scheduled/periodic events.
+`CloudWatch Events
+<http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/WhatIsCloudWatchEvents.html>`_
+(CWE) is a general event bus for AWS infrastructure. Currently, it covers
+several major sources of information:
 
-CloudTrail provides a very rich data source over the entire range
-of AWS services exposed via the audit trail that allows Custodian to define effective
-realtime policies against any AWS product.
+#. CloudTrail API calls over a poll period on CloudTrail delivery,
+#. real-time instance status events,
+#. autoscale group notifications, and
+#. scheduled/periodic events.
 
-Additionally, for EC2 instances we can provide mandatory policy
-compliance - this means the non-compliant resources never
-became available.
+CloudTrail provides a very rich data source over the entire range of AWS
+services exposed via the audit trail that allows Custodian to define effective
+realtime policies against any AWS product. Additionally, for EC2 instances we
+can provide mandatory policy compliance - this means the non-compliant
+resources never became available.
 
 Cloud Custodian Integration
 ===========================
 
-Custodian provides for policy level execution against any CWE event
-stream. Each Custodian policy can be deployed as an independent Lambda
-function. The only difference between a Custodian policy that runs in
-Lambda and one that runs directly from the CLI in poll mode
-is the specification of the subscription of the events in the mode config block of the policy.
+Custodian provides for policy level execution against any CWE event stream.
+Each Custodian policy can be deployed as an independent Lambda function. The
+only difference between a Custodian policy that runs in Lambda and one that
+runs directly from the CLI in poll mode is the specification of the
+subscription of the events in the mode config block of the policy.
 
 Internally Custodian will reconstitute current state for all the resources
 in the event, execute the policy against them, match against the
 policy filters, and apply the policy actions to matching resources.
 
-:ref:`Mu<mu>` is the letter after Lambda, Lambda is a keyword in python.
 
-Configuration
-=============
+CloudTrail API Calls
+++++++++++++++++++++
 
-Examples
+Lambdas can receive CWE over CloudTrail API calls with delay of 90s at P99.
 
 .. code-block:: yaml
 
    policies:
-
-     # Cloud Watch Events over CloudTrail api calls (1-15m trailing)
-     - name: ec2-tag-compliance
+     - name: ec2-tag-running
        resource: ec2
-
-       # The mode block is the only difference between a Custodian policy that
-       # runs in reactive/push mode via lambda and one that runs in poll mode.
        mode:
          type: cloudtrail
          events:
           - RunInstances
-
-         # Note because the total AWS API surface area is so large
-         # most CloudTrail API event subscriptions need two additional
-         # fields.
-         #
-         # For CloudTrail events we need to reference the source API call
-         # sources:
-         #  - ec2.amazonaws.com
-         #
-         # To work transparently with existing resource policies, we also
-         # need to specify how to extract the resource IDs from the event
-         # via JMESPath so that the resources can be queried.
-         # IDs: "detail.responseElements.instancesSet.items[].instanceId"
-         #
-         # For very common API calls for policies, some shortcuts have
-         # been defined to allow for easier policy writing as for the
-         # RunInstances API call above.
-         #
-
-       filters:
-         - or:
-           - tag:required1: absent
-           - tag:required2: absent
        actions:
-         - stop
+         - type: mark
+           tag: foo
+           msg: bar
 
-     # On EC2 Instance state events (real time, seconds)
+Because the total AWS API surface area is so large most CloudTrail API
+event subscriptions need two additional fields:
+
+#. For CloudTrail events we need to reference the source API call.
+
+#. To work transparently with existing resource policies, we also need to
+   specify how to extract the resource IDs from the event via JMESPath so that
+   the resources can be queried.
+
+For very common API calls for policies, some `shortcuts
+<https://github.com/capitalone/cloud-custodian/blob/master/c7n/cwe.py#L28-L69>`_
+have been defined to allow for easier policy writing as for the
+``RunInstances`` API call above, which expands to:
+
+.. code-block:: yaml
+
+     events:
+      - source: ec2.amazonaws.com
+        event: RunInstances
+        ids: "detail.responseElements.instancesSet.items[].instanceId"
+
+
+EC2 Instance State Events
++++++++++++++++++++++++++
+
+Lambdas can receive EC2 instance state events in real time (seconds delay).
+
+.. code-block:: yaml
+
+   policies:
      - name: ec2-require-encrypted-volumes
        resource: ec2
        mode:
@@ -96,20 +101,24 @@ Examples
            value: False
        actions:
          - mark
-         # TODO delete instance volumes that
-         # are not set to delete on terminate;
-         # currently we have a poll policy that
-         # handles this.
          - terminate
 
-     # Periodic Function
-     # Syntax for scheduler per http://goo.gl/x3oMQ4
-     # Supports both rate per unit time and cron expressions
+
+Periodic Function
++++++++++++++++++
+
+We support both rate per unit time and cron expressions, per `scheduler syntax
+<http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html>`_.
+
+.. code-block:: yaml
+
+   policies:
      - name: s3-bucket-check
        resource: s3
        mode:
          type: periodic
          schedule: "rate(1 day)"
+
 
 Config Rules
 ############
@@ -118,7 +127,8 @@ Config Rules
 <http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules.html>`_
 allow you to invoke logic in response to configuration changes in your AWS
 environment, and Cloud Custodian is the easiest way to write and provision
-Config rules.
+Config rules. Delay here is typically 1-15m (though the SLA on tag-only changes
+is a bit higher).
 
 In this section we'll look at how we would deploy the :ref:`quickstart
 <quickstart>` example using Config. Before you proceed, make sure you've

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -18,7 +18,13 @@ Install Cloud Custodian
 
 To install Cloud Custodian, just run::
 
-  $ pip install c7n
+  $ virtualenv --python=python2 custodian
+  $ source custodian/bin/activate
+  (custodian) $ pip install c7n
+
+(Note that Custodian's `Lambda features <../policy/lambda.html>`_ currently `do
+not work <https://github.com/capitalone/cloud-custodian/issues/193>`_ outside
+of a virtualenv.)
 
 
 .. _write-policy:

--- a/tests/data/placebo/test_account_trail_different_region/cloudtrail.DescribeTrails_1.json
+++ b/tests/data/placebo/test_account_trail_different_region/cloudtrail.DescribeTrails_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "trailList": [
+            {
+                "IncludeGlobalServiceEvents": true, 
+                "Name": "skunk-trails", 
+                "TrailARN": "arn:aws:cloudtrail:us-east-1:644160558196:trail/skunk-trails", 
+                "LogFileValidationEnabled": true, 
+                "IsMultiRegionTrail": false, 
+                "S3BucketName": "custodian-skunk-trails", 
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41", 
+                "HomeRegion": "us-west-2"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "44c9cbc9-5cf4-11e6-93db-530701b43d09", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "44c9cbc9-5cf4-11e6-93db-530701b43d09", 
+                "date": "Sun, 07 Aug 2016 23:11:27 GMT", 
+                "content-length": "359", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_trail_different_region/cloudtrail.GetTrailStatus_1.json
+++ b/tests/data/placebo/test_account_trail_different_region/cloudtrail.GetTrailStatus_1.json
@@ -1,0 +1,52 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "453fe62b-5cf4-11e6-93db-530701b43d09", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "453fe62b-5cf4-11e6-93db-530701b43d09", 
+                "date": "Sun, 07 Aug 2016 23:11:28 GMT", 
+                "content-length": "385", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "LatestNotificationAttemptSucceeded": "", 
+        "LatestDeliveryAttemptTime": "2016-08-07T23:07:56Z", 
+        "LatestDeliveryTime": {
+            "hour": 19, 
+            "__class__": "datetime", 
+            "month": 8, 
+            "second": 56, 
+            "microsecond": 58000, 
+            "year": 2016, 
+            "day": 7, 
+            "minute": 7
+        }, 
+        "LatestDeliveryAttemptSucceeded": "2016-08-07T23:07:56Z", 
+        "IsLogging": true, 
+        "TimeLoggingStarted": "2016-07-24T08:57:57Z", 
+        "StartLoggingTime": {
+            "hour": 4, 
+            "__class__": "datetime", 
+            "month": 7, 
+            "second": 57, 
+            "microsecond": 360000, 
+            "year": 2016, 
+            "day": 24, 
+            "minute": 57
+        }, 
+        "LatestDigestDeliveryTime": {
+            "hour": 19, 
+            "__class__": "datetime", 
+            "month": 8, 
+            "second": 32, 
+            "microsecond": 66000, 
+            "year": 2016, 
+            "day": 7, 
+            "minute": 2
+        }, 
+        "LatestNotificationAttemptTime": "", 
+        "TimeLoggingStopped": ""
+    }
+}

--- a/tests/data/placebo/test_account_trail_different_region/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_trail_different_region/iam.ListAccountAliases_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "423d06f2-5cf4-11e6-a457-3d94cc642596", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "423d06f2-5cf4-11e6-a457-3d94cc642596", 
+                "date": "Sun, 07 Aug 2016 23:11:22 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_trail_different_region/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_trail_different_region/iam.ListRoles_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAWpOmeP01cuwAou0sJ6/jM55TWteIogf1riQQadWE/IT/WjeCtk4PQWywkBniBL2LkCpUKiEJSpa+zu1iLTHg+7", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22config.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJUQKESVQ5AAKMZYH4", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "RoleName": "config-role-us-east-1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/config-role-us-east-1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "404ecb05-5cf4-11e6-a457-3d94cc642596", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "404ecb05-5cf4-11e6-a457-3d94cc642596", 
+                "date": "Sun, 07 Aug 2016 23:11:19 GMT", 
+                "content-length": "1003", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_trail_same_region/cloudtrail.DescribeTrails_1.json
+++ b/tests/data/placebo/test_account_trail_same_region/cloudtrail.DescribeTrails_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "trailList": [
+            {
+                "IncludeGlobalServiceEvents": true, 
+                "Name": "skunk-trails", 
+                "TrailARN": "arn:aws:cloudtrail:us-east-1:644160558196:trail/skunk-trails", 
+                "LogFileValidationEnabled": true, 
+                "IsMultiRegionTrail": false, 
+                "S3BucketName": "custodian-skunk-trails", 
+                "KmsKeyId": "arn:aws:kms:us-east-1:644160558196:key/36812ccf-daaf-49b1-a24b-0eef254ffe41", 
+                "HomeRegion": "us-east-1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "44c9cbc9-5cf4-11e6-93db-530701b43d09", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "44c9cbc9-5cf4-11e6-93db-530701b43d09", 
+                "date": "Sun, 07 Aug 2016 23:11:27 GMT", 
+                "content-length": "359", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_trail_same_region/cloudtrail.GetTrailStatus_1.json
+++ b/tests/data/placebo/test_account_trail_same_region/cloudtrail.GetTrailStatus_1.json
@@ -1,0 +1,52 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "453fe62b-5cf4-11e6-93db-530701b43d09", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "453fe62b-5cf4-11e6-93db-530701b43d09", 
+                "date": "Sun, 07 Aug 2016 23:11:28 GMT", 
+                "content-length": "385", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "LatestNotificationAttemptSucceeded": "", 
+        "LatestDeliveryAttemptTime": "2016-08-07T23:07:56Z", 
+        "LatestDeliveryTime": {
+            "hour": 19, 
+            "__class__": "datetime", 
+            "month": 8, 
+            "second": 56, 
+            "microsecond": 58000, 
+            "year": 2016, 
+            "day": 7, 
+            "minute": 7
+        }, 
+        "LatestDeliveryAttemptSucceeded": "2016-08-07T23:07:56Z", 
+        "IsLogging": true, 
+        "TimeLoggingStarted": "2016-07-24T08:57:57Z", 
+        "StartLoggingTime": {
+            "hour": 4, 
+            "__class__": "datetime", 
+            "month": 7, 
+            "second": 57, 
+            "microsecond": 360000, 
+            "year": 2016, 
+            "day": 24, 
+            "minute": 57
+        }, 
+        "LatestDigestDeliveryTime": {
+            "hour": 19, 
+            "__class__": "datetime", 
+            "month": 8, 
+            "second": 32, 
+            "microsecond": 66000, 
+            "year": 2016, 
+            "day": 7, 
+            "minute": 2
+        }, 
+        "LatestNotificationAttemptTime": "", 
+        "TimeLoggingStopped": ""
+    }
+}

--- a/tests/data/placebo/test_account_trail_same_region/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_trail_same_region/iam.ListAccountAliases_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "423d06f2-5cf4-11e6-a457-3d94cc642596", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "423d06f2-5cf4-11e6-a457-3d94cc642596", 
+                "date": "Sun, 07 Aug 2016 23:11:22 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_trail_same_region/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_trail_same_region/iam.ListRoles_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAWpOmeP01cuwAou0sJ6/jM55TWteIogf1riQQadWE/IT/WjeCtk4PQWywkBniBL2LkCpUKiEJSpa+zu1iLTHg+7", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22config.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJUQKESVQ5AAKMZYH4", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "RoleName": "config-role-us-east-1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/config-role-us-east-1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "404ecb05-5cf4-11e6-a457-3d94cc642596", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "404ecb05-5cf4-11e6-a457-3d94cc642596", 
+                "date": "Sun, 07 Aug 2016 23:11:19 GMT", 
+                "content-length": "1003", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_not_filter/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_not_filter/ec2.DescribeInstances_1.json
@@ -1,0 +1,418 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-060de0f1d0c57ecb7", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 3, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 48, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 55
+                        }, 
+                        "PublicIpAddress": "52.206.167.168", 
+                        "PrivateIpAddress": "172.31.17.185", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-036ee05e8c2ca83b3", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "scot-test", 
+                                "GroupId": "sg-c67c7dba"
+                            }
+                        ], 
+                        "ClientToken": "cADxJ1487908547252", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:da:0f:b2:ae:4c", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "52.206.167.168", 
+                                    "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-621ef8a5", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "52.206.167.168", 
+                                            "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.17.185"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-6d28a93c", 
+                                    "AttachTime": {
+                                        "hour": 3, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 48, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 55
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "scot-test", 
+                                        "GroupId": "sg-c67c7dba"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.17.185"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-027869a1c272ed94a", 
+                                    "AttachTime": {
+                                        "hour": 3, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 49, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 55
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-0f41530069955541e", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 4, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 5, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 10
+                        }, 
+                        "PublicIpAddress": "54.159.69.245", 
+                        "PrivateIpAddress": "172.31.24.158", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-012d153789199a2ea", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-5", 
+                                "GroupId": "sg-45131239"
+                            }
+                        ], 
+                        "ClientToken": "bqAbV1487909404715", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:74:d8:ef:71:3c", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.159.69.245", 
+                                    "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-557e9892", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.159.69.245", 
+                                            "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.24.158"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-74cb4b25", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 5, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-5", 
+                                        "GroupId": "sg-45131239"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.24.158"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-0191e7011b209868f", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 6, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-04165fe1b985c1fa9", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 4, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 23, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 10
+                        }, 
+                        "PublicIpAddress": "54.210.221.39", 
+                        "PrivateIpAddress": "172.31.28.123", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-03d8207d8285cbf53", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-6", 
+                                "GroupId": "sg-dc1312a0"
+                            }
+                        ], 
+                        "ClientToken": "jRBlU1487909422108", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:3d:a6:3c:22:ce", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.210.221.39", 
+                                    "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-d97d9b1e", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.210.221.39", 
+                                            "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.28.123"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-43ca4a12", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 23, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-6", 
+                                        "GroupId": "sg-dc1312a0"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.28.123"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-06a06b913ff0257f0", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 23, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "299cb0be-ef26-4e88-8ae3-b5f6a7f13536", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 24 Feb 2017 04:17:24 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_not_filter/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_ec2_not_filter/ec2.DescribeInstances_2.json
@@ -1,0 +1,418 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-060de0f1d0c57ecb7", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 3, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 48, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 55
+                        }, 
+                        "PublicIpAddress": "52.206.167.168", 
+                        "PrivateIpAddress": "172.31.17.185", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-036ee05e8c2ca83b3", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "scot-test", 
+                                "GroupId": "sg-c67c7dba"
+                            }
+                        ], 
+                        "ClientToken": "cADxJ1487908547252", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:da:0f:b2:ae:4c", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "52.206.167.168", 
+                                    "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-621ef8a5", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "52.206.167.168", 
+                                            "PublicDnsName": "ec2-52-206-167-168.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.17.185"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-17-185.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-6d28a93c", 
+                                    "AttachTime": {
+                                        "hour": 3, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 48, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 55
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "scot-test", 
+                                        "GroupId": "sg-c67c7dba"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.17.185"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-027869a1c272ed94a", 
+                                    "AttachTime": {
+                                        "hour": 3, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 49, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 55
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-0f41530069955541e", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 4, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 5, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 10
+                        }, 
+                        "PublicIpAddress": "54.159.69.245", 
+                        "PrivateIpAddress": "172.31.24.158", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-012d153789199a2ea", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-5", 
+                                "GroupId": "sg-45131239"
+                            }
+                        ], 
+                        "ClientToken": "bqAbV1487909404715", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:74:d8:ef:71:3c", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.159.69.245", 
+                                    "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-557e9892", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.159.69.245", 
+                                            "PublicDnsName": "ec2-54-159-69-245.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.24.158"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-24-158.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-74cb4b25", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 5, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-5", 
+                                        "GroupId": "sg-45131239"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.24.158"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-0191e7011b209868f", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 6, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-04165fe1b985c1fa9", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 4, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 23, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 24, 
+                            "minute": 10
+                        }, 
+                        "PublicIpAddress": "54.210.221.39", 
+                        "PrivateIpAddress": "172.31.28.123", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-03d8207d8285cbf53", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-6", 
+                                "GroupId": "sg-dc1312a0"
+                            }
+                        ], 
+                        "ClientToken": "jRBlU1487909422108", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:3d:a6:3c:22:ce", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.210.221.39", 
+                                    "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-d97d9b1e", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.210.221.39", 
+                                            "PublicDnsName": "ec2-54-210-221-39.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.28.123"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-28-123.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-43ca4a12", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 23, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-6", 
+                                        "GroupId": "sg-dc1312a0"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.28.123"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-06a06b913ff0257f0", 
+                                    "AttachTime": {
+                                        "hour": 4, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 23, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 24, 
+                                        "minute": 10
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "79efab8d-f37b-4941-981a-d5121287b3f2", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 24 Feb 2017 04:17:26 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_not_filter/ec2.DescribeTags_1.json
+++ b/tests/data/placebo/test_ec2_not_filter/ec2.DescribeTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e1ebf138-5e95-43a3-a89f-2fdbe30b16dd", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 24 Feb 2017 04:17:26 GMT"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_ec2_not_filter/ec2.DescribeTags_2.json
+++ b/tests/data/placebo/test_ec2_not_filter/ec2.DescribeTags_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "aef19535-549d-47ce-83d6-0fe1a431a1a2", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 24 Feb 2017 04:17:27 GMT"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.CreateVpc_1.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.CreateVpc_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6def564c-5422-4fda-adb5-27b0fe806e33", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:07 GMT"
+            }
+        }, 
+        "Vpc": {
+            "VpcId": "vpc-ea9cf38d", 
+            "InstanceTenancy": "default", 
+            "Tags": [], 
+            "Ipv6CidrBlockAssociationSet": [], 
+            "State": "pending", 
+            "DhcpOptionsId": "dopt-78ab4f1c", 
+            "CidrBlock": "10.4.0.0/16", 
+            "IsDefault": false
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.DeleteNetworkAclEntry_1.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.DeleteNetworkAclEntry_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ee0d7b3f-6ff3-4868-9f31-a0df65fb0908", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:07 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.DeleteVpc_1.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.DeleteVpc_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "54b46ceb-6752-41e5-b0a8-26cdc000532e", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:09 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribeNetworkAcls_1.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribeNetworkAcls_1.json
@@ -1,0 +1,56 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NetworkAcls": [
+            {
+                "Associations": [], 
+                "NetworkAclId": "acl-a0772fc7", 
+                "VpcId": "vpc-ea9cf38d", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4a0331d-1e72-491d-8d6e-421b88639bf1", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:07 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribeNetworkAcls_2.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribeNetworkAcls_2.json
@@ -1,0 +1,132 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NetworkAcls": [
+            {
+                "Associations": [], 
+                "NetworkAclId": "acl-a0772fc7", 
+                "VpcId": "vpc-ea9cf38d", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }, 
+            {
+                "Associations": [
+                    {
+                        "SubnetId": "subnet-5fb47507", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-8650e1ff"
+                    }, 
+                    {
+                        "SubnetId": "subnet-63c97615", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-7853e201"
+                    }, 
+                    {
+                        "SubnetId": "subnet-15452171", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-7953e200"
+                    }
+                ], 
+                "NetworkAclId": "acl-33266757", 
+                "VpcId": "vpc-4a9ff72e", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }, 
+            {
+                "Associations": [], 
+                "NetworkAclId": "acl-01471966", 
+                "VpcId": "vpc-5ef49939", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "10366450-c0f8-4073-ba20-00f85d1c22f4", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:08 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribePrefixLists_1.json
+++ b/tests/data/placebo/test_network_acl_s3_missing/ec2.DescribePrefixLists_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PrefixLists": [
+            {
+                "PrefixListName": "com.amazonaws.us-west-2.s3", 
+                "Cidrs": [
+                    "54.231.160.0/19", 
+                    "52.218.128.0/17", 
+                    "52.92.32.0/22"
+                ], 
+                "PrefixListId": "pl-68a54001"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4a969693-a0fa-4fa8-973c-ca3db1014a08", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:18:08 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_present/ec2.CreateVpc_1.json
+++ b/tests/data/placebo/test_network_acl_s3_present/ec2.CreateVpc_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8c800f8d-5609-4361-82e4-0ff764251716", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:17:42 GMT"
+            }
+        }, 
+        "Vpc": {
+            "VpcId": "vpc-e69cf381", 
+            "InstanceTenancy": "default", 
+            "Tags": [], 
+            "Ipv6CidrBlockAssociationSet": [], 
+            "State": "pending", 
+            "DhcpOptionsId": "dopt-78ab4f1c", 
+            "CidrBlock": "10.4.0.0/16", 
+            "IsDefault": false
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_present/ec2.DeleteVpc_1.json
+++ b/tests/data/placebo/test_network_acl_s3_present/ec2.DeleteVpc_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c91d76c2-1dde-4597-90d1-98bb984afab0", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:17:44 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_present/ec2.DescribeNetworkAcls_1.json
+++ b/tests/data/placebo/test_network_acl_s3_present/ec2.DescribeNetworkAcls_1.json
@@ -1,0 +1,139 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NetworkAcls": [
+            {
+                "Associations": [], 
+                "NetworkAclId": "acl-de772fb9", 
+                "VpcId": "vpc-e69cf381", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }, 
+            {
+                "Associations": [
+                    {
+                        "SubnetId": "subnet-5fb47507", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-8650e1ff"
+                    }, 
+                    {
+                        "SubnetId": "subnet-63c97615", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-7853e201"
+                    }, 
+                    {
+                        "SubnetId": "subnet-15452171", 
+                        "NetworkAclId": "acl-33266757", 
+                        "NetworkAclAssociationId": "aclassoc-7953e200"
+                    }
+                ], 
+                "NetworkAclId": "acl-33266757", 
+                "VpcId": "vpc-4a9ff72e", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }, 
+            {
+                "Associations": [], 
+                "NetworkAclId": "acl-01471966", 
+                "VpcId": "vpc-5ef49939", 
+                "Tags": [], 
+                "Entries": [
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": true, 
+                        "RuleAction": "deny"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 100, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "allow"
+                    }, 
+                    {
+                        "CidrBlock": "0.0.0.0/0", 
+                        "RuleNumber": 32767, 
+                        "Protocol": "-1", 
+                        "Egress": false, 
+                        "RuleAction": "deny"
+                    }
+                ], 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac8fb334-f8de-4715-92ad-8f4e511ef124", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:17:43 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_network_acl_s3_present/ec2.DescribePrefixLists_1.json
+++ b/tests/data/placebo/test_network_acl_s3_present/ec2.DescribePrefixLists_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PrefixLists": [
+            {
+                "PrefixListName": "com.amazonaws.us-west-2.s3", 
+                "Cidrs": [
+                    "54.231.160.0/19", 
+                    "52.218.128.0/17", 
+                    "52.92.32.0/22"
+                ], 
+                "PrefixListId": "pl-68a54001"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4b0abfec-979f-4330-a17b-d474ea4bc703", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sun, 26 Feb 2017 17:17:44 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-perm-denied", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Mpf+5OmD2gTjcAYau38FEDQDKjV6PnWO1sm10nI+PQDeEN5MFuO7ZMHjhWFHURmmyajIU2njb1o=", 
+            "RequestId": "A46F6C0391D98BF4", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "Mpf+5OmD2gTjcAYau38FEDQDKjV6PnWO1sm10nI+PQDeEN5MFuO7ZMHjhWFHURmmyajIU2njb1o=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "A46F6C0391D98BF4", 
+                "location": "/custodian-perm-denied", 
+                "date": "Sat, 18 Feb 2017 05:03:25 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucketPolicy_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "M3K/2ZzfHN52JaCfSvPRpCzxSXaYn4wD7a8J/3uSeZJPvr0Iyq8rPHemaJrg3bVhv9D0lw6OeHo=", 
+            "RequestId": "8CA00C5B0503DC3D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "M3K/2ZzfHN52JaCfSvPRpCzxSXaYn4wD7a8J/3uSeZJPvr0Iyq8rPHemaJrg3bVhv9D0lw6OeHo=", 
+                "date": "Sat, 18 Feb 2017 05:03:37 GMT", 
+                "x-amz-request-id": "8CA00C5B0503DC3D", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucket_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 403, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 403, 
+            "RetryAttempts": 0, 
+            "HostId": "0saYK+LxXeZJQlWpHh9mhl3KxSk0iMNlWriDnHn9xlP5uAEpF03Qjj5t9L3Wy4RP+sigE2C5Qq4=", 
+            "RequestId": "CB2D430E66B2A744", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "0saYK+LxXeZJQlWpHh9mhl3KxSk0iMNlWriDnHn9xlP5uAEpF03Qjj5t9L3Wy4RP+sigE2C5Qq4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "CB2D430E66B2A744", 
+                "date": "Sat, 18 Feb 2017 05:03:33 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "Access Denied", 
+            "Code": "AccessDenied"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucket_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteBucket_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "9OZbZGP1ATvYeDJhLfFGbj+VkT+5XioGHDnnwT1kiNAlhNW1796NxQ17onyMzInx1+lEbj+Q7sk=", 
+            "RequestId": "EAB8128BE4F8E17C", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "9OZbZGP1ATvYeDJhLfFGbj+VkT+5XioGHDnnwT1kiNAlhNW1796NxQ17onyMzInx1+lEbj+Q7sk=", 
+                "date": "Sat, 18 Feb 2017 05:03:39 GMT", 
+                "x-amz-request-id": "EAB8128BE4F8E17C", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteObjects_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.DeleteObjects_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Deleted": [
+            {
+                "Key": "AWSLogs/2015/10/10"
+            }, 
+            {
+                "Key": "AWSLogs/2015/10/11"
+            }, 
+            {
+                "Key": "home.txt"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "MKK4/lgEZAO/2/rWA0y/IP+Lt9faIRCERA5NYXlW3c0wXMIX2TCcy32m5R1SZmWTB2h+GKwox7w=", 
+            "RequestId": "AF0503BFB6D0DFE7", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "MKK4/lgEZAO/2/rWA0y/IP+Lt9faIRCERA5NYXlW3c0wXMIX2TCcy32m5R1SZmWTB2h+GKwox7w=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "connection": "close", 
+                "x-amz-request-id": "AF0503BFB6D0DFE7", 
+                "date": "Sat, 18 Feb 2017 05:03:34 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_1.json
@@ -1,0 +1,168 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 6
+                }, 
+                "Name": "config-rule-sanity"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 2
+                }, 
+                "Name": "custodian-perm-denied"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 57
+                }, 
+                "Name": "custodian-replicated-west"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 17, 
+                    "minute": 16
+                }, 
+                "Name": "scot-test2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 9, 
+                    "minute": 46
+                }, 
+                "Name": "sphere11-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 15
+                }, 
+                "Name": "sphere11-dev-us-west-2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 14
+                }, 
+                "Name": "sphere11-us-west-2-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 30, 
+                    "minute": 8
+                }, 
+                "Name": "whit537-297"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Qx3xAhmgvJ6bYIMiVTP+CUpZCeHYIoBjIcQQyRMXJDxo32iO7Z7y7HepUi5NCe65Vg0ee2iuoOU=", 
+            "RequestId": "8873DA58AC0A5F69", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Qx3xAhmgvJ6bYIMiVTP+CUpZCeHYIoBjIcQQyRMXJDxo32iO7Z7y7HepUi5NCe65Vg0ee2iuoOU=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8873DA58AC0A5F69", 
+                "date": "Sat, 18 Feb 2017 05:03:31 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_2.json
@@ -1,0 +1,168 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 6
+                }, 
+                "Name": "config-rule-sanity"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 2
+                }, 
+                "Name": "custodian-perm-denied"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 57
+                }, 
+                "Name": "custodian-replicated-west"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 17, 
+                    "minute": 16
+                }, 
+                "Name": "scot-test2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 9, 
+                    "minute": 46
+                }, 
+                "Name": "sphere11-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 15
+                }, 
+                "Name": "sphere11-dev-us-west-2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 14
+                }, 
+                "Name": "sphere11-us-west-2-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 30, 
+                    "minute": 8
+                }, 
+                "Name": "whit537-297"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "wtUAliezyumcy6xaLLDAukOmJXCVx+bGW+slMTzuRhg4gqoEHOwJUAjp02aGGnJrc2JNLcDyZ4U=", 
+            "RequestId": "8E2629BC442A9565", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "wtUAliezyumcy6xaLLDAukOmJXCVx+bGW+slMTzuRhg4gqoEHOwJUAjp02aGGnJrc2JNLcDyZ4U=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8E2629BC442A9565", 
+                "date": "Sat, 18 Feb 2017 05:03:36 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_3.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_3.json
@@ -1,0 +1,168 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 6
+                }, 
+                "Name": "config-rule-sanity"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 2
+                }, 
+                "Name": "custodian-perm-denied"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 57
+                }, 
+                "Name": "custodian-replicated-west"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 17, 
+                    "minute": 16
+                }, 
+                "Name": "scot-test2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 9, 
+                    "minute": 46
+                }, 
+                "Name": "sphere11-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 15
+                }, 
+                "Name": "sphere11-dev-us-west-2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 14
+                }, 
+                "Name": "sphere11-us-west-2-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 30, 
+                    "minute": 8
+                }, 
+                "Name": "whit537-297"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "3hWGUgD2P4x3dyogaAP/74evbLUeFhGB0AA/L3K5pj7i44J0NzQP0XsDGUqwiEZq/XP4OKH9xbQ=", 
+            "RequestId": "BE7BC6C45170F1A8", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "3hWGUgD2P4x3dyogaAP/74evbLUeFhGB0AA/L3K5pj7i44J0NzQP0XsDGUqwiEZq/XP4OKH9xbQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BE7BC6C45170F1A8", 
+                "date": "Sat, 18 Feb 2017 05:03:37 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_4.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListBuckets_4.json
@@ -1,0 +1,155 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 6
+                }, 
+                "Name": "config-rule-sanity"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 57
+                }, 
+                "Name": "custodian-replicated-west"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 17, 
+                    "minute": 16
+                }, 
+                "Name": "scot-test2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 9, 
+                    "minute": 46
+                }, 
+                "Name": "sphere11-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 15
+                }, 
+                "Name": "sphere11-dev-us-west-2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 14
+                }, 
+                "Name": "sphere11-us-west-2-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 30, 
+                    "minute": 8
+                }, 
+                "Name": "whit537-297"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "9XNQ/f+oSpoCoYwQFfmqh7tqnQbsZaF8v7ffmgmWFbuF2sHRQwwBR0cUR15hmlTP8dyIz1beAyA=", 
+            "RequestId": "C315998FA8E1C70A", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "9XNQ/f+oSpoCoYwQFfmqh7tqnQbsZaF8v7ffmgmWFbuF2sHRQwwBR0cUR15hmlTP8dyIz1beAyA=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "C315998FA8E1C70A", 
+                "date": "Sat, 18 Feb 2017 05:03:40 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListMultipartUploads_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListMultipartUploads_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200, 
+    "data": {
+        "UploadIdMarker": "", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "XxGx7F93WdEznAWj1GHAnG6ySASqHXDTVkNsjsn2K4ryWbEJMHScBUeI7nZ8gvhXWmvYErrN4IQ=", 
+            "RequestId": "59F0B4314A718EBB", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "XxGx7F93WdEznAWj1GHAnG6ySASqHXDTVkNsjsn2K4ryWbEJMHScBUeI7nZ8gvhXWmvYErrN4IQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "59F0B4314A718EBB", 
+                "date": "Sat, 18 Feb 2017 05:03:33 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "NextKeyMarker": "", 
+        "Bucket": "custodian-perm-denied", 
+        "NextUploadIdMarker": "", 
+        "KeyMarker": "", 
+        "MaxUploads": 1000, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListMultipartUploads_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListMultipartUploads_2.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200, 
+    "data": {
+        "UploadIdMarker": "", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "gUqAONhSTLu7jdMc1CCbbMW6+dNWrr/cUzGXgFmkWHJP/4XaTOx6cSdySlvYh630HGWC4mIbur0=", 
+            "RequestId": "4377048D6EE349D6", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "gUqAONhSTLu7jdMc1CCbbMW6+dNWrr/cUzGXgFmkWHJP/4XaTOx6cSdySlvYh630HGWC4mIbur0=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4377048D6EE349D6", 
+                "date": "Sat, 18 Feb 2017 05:03:38 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "NextKeyMarker": "", 
+        "Bucket": "custodian-perm-denied", 
+        "NextUploadIdMarker": "", 
+        "KeyMarker": "", 
+        "MaxUploads": 1000, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListObjects_1.json
@@ -1,0 +1,88 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Name": "custodian-perm-denied", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "m3yTHATea77MC6mDh/PESUBdBhA3oURxtw9kQHhnyWLUNX1di3tEWgKRHMHn9MC6f6GhF3msFMM=", 
+            "RequestId": "B19B867D5DE66D2B", 
+            "HTTPHeaders": {
+                "x-amz-bucket-region": "us-east-1", 
+                "x-amz-id-2": "m3yTHATea77MC6mDh/PESUBdBhA3oURxtw9kQHhnyWLUNX1di3tEWgKRHMHn9MC6f6GhF3msFMM=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "B19B867D5DE66D2B", 
+                "date": "Sat, 18 Feb 2017 05:03:34 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false, 
+        "Contents": [
+            {
+                "LastModified": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 3
+                }, 
+                "ETag": "\"c68271a63ddbc431c307beb7d2918275\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "AWSLogs/2015/10/10", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 3
+            }, 
+            {
+                "LastModified": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 3
+                }, 
+                "ETag": "\"b2e189abf85e809a51522cdb0e53083a\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "AWSLogs/2015/10/11", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 4
+            }, 
+            {
+                "LastModified": {
+                    "hour": 5, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 3
+                }, 
+                "ETag": "\"5d41402abc4b2a76b9719d911017c592\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "home.txt", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 5
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListObjects_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.ListObjects_2.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200, 
+    "data": {
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Name": "custodian-perm-denied", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "CzLDEoc9noKeuprt7U0hfrT4Odw/mxx7+Co8C9JzpcNoL9pcXslRIp04aIoxeQE/N834UwnKD2w=", 
+            "RequestId": "E09BADA7215E17DC", 
+            "HTTPHeaders": {
+                "x-amz-bucket-region": "us-east-1", 
+                "x-amz-id-2": "CzLDEoc9noKeuprt7U0hfrT4Odw/mxx7+Co8C9JzpcNoL9pcXslRIp04aIoxeQE/N834UwnKD2w=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "E09BADA7215E17DC", 
+                "date": "Sat, 18 Feb 2017 05:03:39 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutBucketPolicy_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "A4hQty3hdaj1Xlpk3GhmoYUuVHPM656Q8X6DYazen57aJULM2JOn47ujnDiBas2CbdvXb4jG/MI=", 
+            "RequestId": "F8C31C22D36DE47D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "A4hQty3hdaj1Xlpk3GhmoYUuVHPM656Q8X6DYazen57aJULM2JOn47ujnDiBas2CbdvXb4jG/MI=", 
+                "date": "Sat, 18 Feb 2017 05:03:29 GMT", 
+                "x-amz-request-id": "F8C31C22D36DE47D", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ETag": "\"b2e189abf85e809a51522cdb0e53083a\"", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "qT/Zwk726p0zMHlLBWbxUSt88YZghqllNlIcpdHmISlAwSxwAjMmMVOARQblJ8EhKZoq140SmJQ=", 
+            "RequestId": "4AAF9A2DEF4655CB", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "qT/Zwk726p0zMHlLBWbxUSt88YZghqllNlIcpdHmISlAwSxwAjMmMVOARQblJ8EhKZoq140SmJQ=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "4AAF9A2DEF4655CB", 
+                "etag": "\"b2e189abf85e809a51522cdb0e53083a\"", 
+                "date": "Sat, 18 Feb 2017 05:03:28 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ETag": "\"5d41402abc4b2a76b9719d911017c592\"", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "RWUIhkAHoxXmojmajaZS4Y9VbiY6ucN/DClD48QRh3PPkdEKgeB9wYIsu95/rQtJqEkpWevv6B4=", 
+            "RequestId": "EB240A0812F808B5", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "RWUIhkAHoxXmojmajaZS4Y9VbiY6ucN/DClD48QRh3PPkdEKgeB9wYIsu95/rQtJqEkpWevv6B4=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "EB240A0812F808B5", 
+                "etag": "\"5d41402abc4b2a76b9719d911017c592\"", 
+                "date": "Sat, 18 Feb 2017 05:03:28 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_3.json
+++ b/tests/data/placebo/test_s3_delete_bucket_with_failure/s3.PutObject_3.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ETag": "\"c68271a63ddbc431c307beb7d2918275\"", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "x+D4lOZ5KkHTpq8PxVNtWFO0a5xA5gjA5jouxS+1q+GlF3cVfepyX08OzQIiGkxPem5FF/C21yw=", 
+            "RequestId": "A213AE52C487FA1B", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "x+D4lOZ5KkHTpq8PxVNtWFO0a5xA5gjA5jouxS+1q+GlF3cVfepyX08OzQIiGkxPem5FF/C21yw=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "A213AE52C487FA1B", 
+                "etag": "\"c68271a63ddbc431c307beb7d2918275\"", 
+                "date": "Sat, 18 Feb 2017 05:03:28 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -54,6 +54,42 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_cloudtrail_current_region_global(self):
+        session_factory = self.replay_flight_data('test_account_trail')
+        p = self.load_policy({
+            'name': 'trail-global',
+            'resource': 'account',
+            'filters': [
+                {'type': 'check-cloudtrail',
+                 'current-region': True,
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_cloudtrail_current_region_specific_same(self):
+        session_factory = self.replay_flight_data('test_account_trail_same_region')
+        p = self.load_policy({
+            'name': 'trail-same-region',
+            'resource': 'account',
+            'filters': [
+                {'type': 'check-cloudtrail',
+                 'current-region': True,
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_cloudtrail_current_region_specific_same(self):
+        session_factory = self.replay_flight_data('test_account_trail_different_region')
+        p = self.load_policy({
+            'name': 'trail-different-region',
+            'resource': 'account',
+            'filters': [
+                {'type': 'check-cloudtrail',
+                 'current-region': True,
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_cloudtrail_notifies(self):
         session_factory = self.replay_flight_data('test_account_trail')
         p = self.load_policy({

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -830,3 +830,41 @@ class TestModifySecurityGroupAction(BaseTest):
         self.assertEqual(len(
             second_resources[0]['NetworkInterfaces'][0]['Groups']), 2)
 
+
+class TestFilter(BaseTest):
+    
+    def test_not_filter(self):
+        # This test is to get coverage for the `not` filter's process_set method
+        session_factory = self.replay_flight_data(
+            'test_ec2_not_filter')
+
+        policy = self.load_policy({
+            'name': 'list-ec2-test-not',
+            'resource': 'ec2',
+            'filters': [{
+                'not': [
+                    {'InstanceId': 'i-036ee05e8c2ca83b3'}
+                ]
+            }]
+        },
+        session_factory=session_factory)
+
+        resources = policy.run()
+        self.assertEqual(len(resources), 2)
+
+        policy = self.load_policy({
+            'name': 'list-ec2-test-not',
+            'resource': 'ec2',
+            'filters': [{
+                'not': [{
+                    'or': [
+                        {'InstanceId': 'i-036ee05e8c2ca83b3'},
+                        {'InstanceId': 'i-03d8207d8285cbf53'}
+                    ]
+                }]
+            }]
+        },
+        session_factory=session_factory)
+
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -95,6 +95,39 @@ class TestAndFilter(unittest.TestCase):
             [])
 
 
+class TestNotFilter(unittest.TestCase):
+    
+    def test_not(self):
+
+        results = [
+            instance(Architecture='x86_64', Color='green'),
+            instance(Architecture='x86_64', Color='blue'),
+            instance(Architecture='x86_64', Color='yellow'),
+        ]
+
+        f = filters.factory({
+            'not': [
+                {'Architecture': 'x86_64'},
+                {'Color': 'green'}]})
+        self.assertEqual(len(f.process(results)), 2)
+        
+        """
+        f = filters.factory({
+            'not': [
+                {'Architecture': 'x86'}]})
+        self.assertEqual(len(f.process(results)), 3)
+
+        f = filters.factory({
+            'not': [
+                {'Architecture': 'x86_64'},
+                {'or': [
+                    {'Color': 'green'},
+                    {'Color': 'blue'},
+                    {'Color': 'yellow'},
+                ]}]})
+        self.assertEqual(len(f.process(results)), 0)
+        """
+
 class TestValueFilter(unittest.TestCase):
 
     # TODO test_manager needs a valid session_factory object

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -112,7 +112,7 @@ class PolicyPermissions(BaseTest):
                         k, n))
 
             for n, f in v.filter_registry.items():
-                if n in ('and', 'or'):
+                if n in ('and', 'or', 'not'):
                     continue
                 p['filters'] = [n]
                 perms = f({}, mgr).get_permissions()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -36,7 +36,7 @@ class SchemaTest(BaseTest):
     def test_schema_plugin_name_mismatch(self):
         for k, v in resources.items():
             for fname, f in v.filter_registry.items():
-                if fname in ('or', 'and'):
+                if fname in ('or', 'and', 'not'):
                     continue
                 self.assertIn(
                     fname, f.schema['properties']['type']['enum'])

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -131,7 +131,7 @@ schema](./c7n_mailer/cli.py#L11-L41) to which the file must conform, here is
 |           | `ldap_bind_user`     | string           | ldap server for resolving users     |
 |           | `ldap_bind_password` | string           | ldap server for resolving users     |
 |           | `ldap_uri`           | string           | ldap server for resolving users     |
-
+|           | `ses_region`         | string           | AWS region that handles SES API calls |
 
 #### SDK Config
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = {
         'ldap_bind_user': {'type': 'string'},
         'ldap_bind_password': {'type': 'string'},
         'cross_accounts': {'type': 'object'},
+        'ses_region': {'type': 'string'},
 
         # SDK Config
         'profile': {'type': 'string'},

--- a/tools/c7n_mailer/c7n_mailer/processor.py
+++ b/tools/c7n_mailer/c7n_mailer/processor.py
@@ -44,7 +44,7 @@ class Processor(object):
 
     def __init__(self, config, session, cache):
         self.config = config
-        self.ses = session.client('ses')
+        self.ses = session.client('ses', region_name=config.get('ses_region'))
         self.sts = session.client('sts')
         self.sns_cache = {}
         self.cache = cache

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -23,6 +23,7 @@ def format_struct(struct):
 
 def setup_defaults(config):
     config.setdefault('region', 'us-east-1')
+    config.setdefault('ses_region', config.get('region'))
     config.setdefault('memory', 1024)
     config.setdefault('timeout', 300)
     config.setdefault('subnets', None)

--- a/tools/c7n_mailer/c7n_mailer/worker.py
+++ b/tools/c7n_mailer/c7n_mailer/worker.py
@@ -76,7 +76,7 @@ class Worker(object):
         self.processor = Processor(self.config, session, self.cache)
 
     def run(self):
-        self.ses = self.session.client('ses')
+        self.ses = self.session.client('ses', region_name=self.config.get('ses_region'))
 
         log.info("Queue poll loop")
         while True:

--- a/tools/c7n_salactus/c7n_salactus/worker.py
+++ b/tools/c7n_salactus/c7n_salactus/worker.py
@@ -90,10 +90,11 @@ connection = redis.Redis(host=REDIS_HOST)
 # seeing some odd net slowness all around.
 s3config = Config(read_timeout=420, connect_timeout=90)
 keyconfig = {
-    'report-only': True,
+    'report-only': os.environ.get('SALACTUS_ENCRYPT') and False or True,
     'glacier': False,
     'large': True,
-    'crypto': 'AES256'}
+    'key-id': os.environ.get('SALACTUS_KEYID'),
+    'crypto': os.environ.get('SALACTUS_CRYPTO', 'AES256')}
 
 log = logging.getLogger("salactus")
 


### PR DESCRIPTION
This makes check-cloudtrail able to check if the given region is
covered, at all - not just via multi region.

This lets us run it against individual regions to check cloud trail
logging / auditing.